### PR TITLE
chore: use oidc release

### DIFF
--- a/.changeset/late-pandas-turn.md
+++ b/.changeset/late-pandas-turn.md
@@ -1,5 +1,0 @@
----
-'@ai-billing/core': patch
----
-
-chore: test alpha release pipeline

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,25 +14,27 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build Packages
-        run: pnpm turbo run build
+        run: pnpm run build
 
       - name: Create Release Pull Request or Publish
         id: changesets
@@ -44,4 +46,3 @@ jobs:
           title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,11 @@
     "name": "@ai-billing/core",
     "version": "0.0.1-alpha.0",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/narevai/ai-billing.git",
+        "directory": "packages/core"
+    },
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "exports": {


### PR DESCRIPTION
Using oidcs to push to `npm`