### PR TITLE
chore: schedule release after ci

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -1,8 +1,12 @@
 name: Code Quality Check
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["Code Quality Check"]
+    types:
+      - completed
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -1,12 +1,8 @@
 name: Code Quality Check
 
 on:
-  workflow_run:
-    workflows: ["Code Quality Check"]
-    types:
-      - completed
-    branches:
-      - main
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   workflow_run:
-    workflows: ["Code Quality Check"]
+    workflows: ['Code Quality Check']
     types:
       - completed
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Code Quality Check"]
+    types:
+      - completed
     branches:
       - main
 


### PR DESCRIPTION
- release workflow fires on CI success on main (not in parallel)