### PR TITLE
docs: remove portkey from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ const { textStream } = await streamText({
 * [OpenAI Compatible Providers](https://ai-sdk.dev/providers/openai-compatible-providers#openai-compatible-providers) ([#45](https://github.com/narevai/ai-billing/issues/45))
 * [Anthropic](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic) ([#46](https://github.com/narevai/ai-billing/issues/46))
 * [Google Generative AI](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai) ([#47](https://github.com/narevai/ai-billing/issues/47))
-* [Portkey](https://ai-sdk.dev/providers/community-providers/portkey) ([#57](https://github.com/narevai/ai-billing/issues/57))
 * [Requesty](https://ai-sdk.dev/providers/community-providers/requesty)
 * [Cloudflare AI Gateway](https://ai-sdk.dev/providers/community-providers/cloudflare-ai-gateway)
 


### PR DESCRIPTION
- portkey relies on `openai` provider which is already implemented in `@ai-billing/openai`