### PR TITLE
fix: realign package versioning

### DIFF
--- a/.changeset/real-groups-joke.md
+++ b/.changeset/real-groups-joke.md
@@ -1,0 +1,8 @@
+---
+"@ai-billing/openmeter": patch
+"@ai-billing/stripe": patch
+"@ai-billing/polar": patch
+"@ai-billing/lago": patch
+---
+
+realign package versions

--- a/packages/lago/package.json
+++ b/packages/lago/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-billing/lago",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {

--- a/packages/openmeter/package.json
+++ b/packages/openmeter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-billing/openmeter",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {

--- a/packages/polar/package.json
+++ b/packages/polar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-billing/polar",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-billing/stripe",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {


### PR DESCRIPTION
- accidental release to `1.0.0` instead of `0.1.0` in https://github.com/narevai/ai-billing/pull/116
- realigning packages to `0.1.0` and adding a patch changeset
- deprecated `1.0.0` packages on npm