### PR TITLE
chore: ignore node and pnpm in github actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
     },
     {
       "description": "Group Tooling & Environment (Weekly)",
-      "matchPackageNames": ["pnpm", "turbo", "typescript", "vitest", "knip", "tsup", "oxfmt", "oxlint", "@changesets/cli"],
+      "matchPackageNames": ["turbo", "typescript", "vitest", "knip", "tsup", "oxfmt", "oxlint", "@changesets/cli"],
       "matchPackagePatterns": ["^@vitest/", "^eslint-", "^@types/"],
       "groupName": "Dev Tooling",
       "schedule": ["every weekend"]


### PR DESCRIPTION
- renovate bumps node version in github actions
- since we're doing matrix tests, this is not relevant